### PR TITLE
simplify / bump Node.js versions in Travis; set package.json "engines"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: node_js
 node_js:
-- stable
-- 5.4.1
-- 5.4.0
-- 5.3.0
-- 5.2.0
-- 5.1.1
-- 4.4.6
+- '4'
+- '5'
+- '6'
 before_install:
 - npm install -g typings
 - npm install -g codeclimate-test-reporter

--- a/package.json
+++ b/package.json
@@ -67,5 +67,9 @@
     "transform": [
       "envify"
     ]
+  },
+  "engines": {
+    "node": ">=4.0.0",
+    "npm": ">=3.0.0"
   }
 }


### PR DESCRIPTION
## Description
- reduce Node.js version in Travis CI to just the latest of each major version: 4.x, 5.x
- add Node.js 6.x explicitly

## Motivation and Context
- Travis CI tests can fail randomly, so avoid running unnecessarily repetative scenarios
- Node.js 5.x is no longer maintained by upstream, so we should reduce our testing there
- https://nodejs.org/en/blog/release/v6.0.0/
- https://github.com/nodejs/LTS/
- add Node.js 6.x explicitly, as "stable" will mean Node.js 7.x in October and we still want to test against 6.x when that happens

## How Has This Been Tested?
- tested by Travis CI: https://travis-ci.org/redux-bootstrap/redux-bootstrap/builds/150765695

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

- this sort of reduces the likelihood of random Travis CI failures, so I guess that's a bug fix?

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
